### PR TITLE
ci: add npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,19 @@ on:
       - main
       - alpha
       - beta
+
+permissions:
+  contents: read # for checkout
+
 jobs:
   release:
     name: Release
     permissions:
-      pull-requests: write
       actions: write
-      contents: write
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
Add npm provenance : https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#npm-provenance