### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/jy95/docusaurus-json-schema-plugin/security/code-scanning/4](https://github.com/jy95/docusaurus-json-schema-plugin/security/code-scanning/4)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/tests.yml`. This block can be added at the root level (applies to all jobs) or at the job level (applies only to the specified job). Since the workflow appears to only need to read repository contents (for checkout and running tests) and possibly write to pull requests (if reporting coverage status), the minimal starting point is to set `contents: read`. If you know that the workflow needs to write to pull requests (e.g., to post coverage comments), you can also add `pull-requests: write`. The best way to implement this is to add the following block after the `name:` line and before the `on:` line:

```yaml
permissions:
  contents: read
```

If you later determine that more permissions are needed, you can adjust this block accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
