### PR TITLE
docs: Update JSONSchemaViewer.mdx

### DIFF
--- a/testsite/docs/api/JSONSchemaViewer.mdx
+++ b/testsite/docs/api/JSONSchemaViewer.mdx
@@ -60,6 +60,16 @@ type JSVOptions = {
      * @default undefined
      */
     UnresolvedRefsComponent?: (params: { schema: JSONSchema }) => JSX.Element
+    /**
+     * Defines how deep the schema should be expanded by default
+     * Examples:
+     *  - 0: only the root level is expanded
+     *  - 1: root level and its direct children are expanded
+     *  - Infinity: expand all levels
+     * @default 0
+     * @min 0
+     */
+    defaultExpandDepth?: number
 }
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JSONSchemaViewer API docs to include an optional defaultExpandDepth setting in JSVOptions, explaining how to control the initial schema expansion depth. Provided examples (0, 1, Infinity), the default (0), and the minimum (0) to guide configuration. This is a documentation/type declaration enhancement only; no changes to existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->