### PR TITLE
Update docusaurus.config.js

### DIFF
--- a/testsite/docusaurus.config.js
+++ b/testsite/docusaurus.config.js
@@ -11,11 +11,15 @@ module.exports = {
   url: "https://jy95.github.io",
   baseUrl: baseUrl,
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",
   trailingSlash: false, // Needed for Gh pages - https://github.com/facebook/docusaurus/issues/5026
   organizationName: "jy95", // Usually your GitHub org/user name.
   projectName: "docusaurus-json-schema-plugin", // Usually your repo name.
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn'
+    }
+  },
   themeConfig: {
     algolia: {
       appId: "IQ028YCDJT",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated site configuration related to Markdown link handling. Behavior remains the same: builds and local development will continue to warn on broken Markdown links. No user-facing changes to functionality or appearance. Editors and contributors should experience the same warning behavior during content edits. No action required for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->